### PR TITLE
[sankey] Fix Broken Sorting for the Nodes

### DIFF
--- a/public/lib/agg_response_helper.js
+++ b/public/lib/agg_response_helper.js
@@ -65,16 +65,10 @@ module.exports = (function() {
     return nodeIdMap;
   }
 
-  function _generateSortedNodeArray(nodesMap) {
+  function _generateNodeArray(nodesMap) {
     const nodeArray = [];
-    // create sort array
     nodesMap.forEach((nodeName, nodeId) => {
       nodeArray.push({ nodeId, name: nodeName });
-    });
-    nodeArray.sort((node1,node2) => {
-      const node1Name = node1.name.toString();
-      const node2Name = node2.name.toString();
-      return node1Name.localeCompare(node2Name);
     });
     return nodeArray;
   }
@@ -129,7 +123,7 @@ module.exports = (function() {
     const paths = _convertObjectToArray({rows, missingValues, groupBucket});
     const nodesMap = _generateNodesMap(paths);
     const linksMap = _generateLinksMap(paths, nodesMap);
-    const nodes = _generateSortedNodeArray(nodesMap);
+    const nodes = _generateNodeArray(nodesMap);
     const nodeIdMap = _generateNodeIdMap(nodes);
     const convertedLinks = _convertLinksMapToArray(linksMap, nodeIdMap);
     const cleanedD3Nodes = nodes.map(({name}) => { return { name }; });
@@ -146,7 +140,7 @@ module.exports = (function() {
     _getNodeId,
     _generateLinksMap,
     _generateNodeIdMap,
-    _generateSortedNodeArray,
+    _generateNodeArray,
     _convertLinksMapToArray,
 
     aggregate

--- a/test/agg_response_helperTest.js
+++ b/test/agg_response_helperTest.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 
-const stringify = require('json-stable-stringify');
 const aggResponseHelper = require('../public/lib/agg_response_helper');
 
 describe('aggResponseHelper', function() {
@@ -32,7 +31,7 @@ describe('aggResponseHelper', function() {
         { source: 1, target: 5, value: 90 },
         { source: 0, target: 5, value: 90 },
       ];
-      const result = aggResponseHelper.aggregate(data); 
+      const result = aggResponseHelper.aggregate(data);
       const result_nodes = result.nodes;
       const result_links = result.links;
       assert.notStrictEqual(result_nodes, expected_nodes);
@@ -66,32 +65,9 @@ describe('aggResponseHelper', function() {
         { name: 'node0' },
         { name: 'node0' }
       ];
-      const result = aggResponseHelper.aggregate(data); 
+      const result = aggResponseHelper.aggregate(data);
       const result_nodes = result.nodes;
       assert.notStrictEqual(result_nodes, expected_nodes);
-    });
-  });
-
-  describe('privateFkt_generateRefNodesIdMap', function() {
-    it('should create nodes in the right order', function() {
-      /*
-       * n0 - n3 - n2
-       * n1 - n2 - n1
-       */
-      const data = [
-        [ 'node0', 'node3', 'node2', 90 ],
-        [ 'node1', 'node2', 'node1', 90 ]
-      ];
-      const nodesMap = new Map();
-      nodesMap.set(stringify({"layerIndex":0,"nodeName":"node0"}), 'node0');
-      nodesMap.set(stringify({"layerIndex":1,"nodeName":"node3"}), 'node3');
-      nodesMap.set(stringify({"layerIndex":2,"nodeName":"node2"}), 'node2');
-      nodesMap.set(stringify({"layerIndex":0,"nodeName":"node1"}), 'node1');
-      nodesMap.set(stringify({"layerIndex":1,"nodeName":"node2"}), 'node2');
-      nodesMap.set(stringify({"layerIndex":2,"nodeName":"node1"}), 'node1');
-       
-      const result = aggResponseHelper._generateSortedNodeArray(nodesMap);
-      //console.log('RESULT: ',result);
     });
   });
 


### PR DESCRIPTION
 This PR should make it possible to use Kibana's sorting feature in order to sort the Nodes.
You can find this feature under '**bucket aggregation**' then select '**order by**'.
<img width="296" alt="sankeySort2" src="https://user-images.githubusercontent.com/18037647/100736075-86a45f00-33d2-11eb-9970-5d548431b3c5.png">
As a result, the desired aggregation should be sorted in the **Sankey** **Visualisation** .
